### PR TITLE
make meta filepath flexible

### DIFF
--- a/examples/run.py
+++ b/examples/run.py
@@ -147,6 +147,7 @@ if __name__ == "__main__":
     # inputs
     i_folder = "examples/data"
     o_folder = "examples/results"
+    meta_filename = "meta.yaml"
     locations = ["AUT"]
 
-    main(DataManager(i_folder, o_folder, locations))
+    main(DataManager(i_folder, o_folder, meta_filename, locations))

--- a/src/emmodel/data.py
+++ b/src/emmodel/data.py
@@ -16,6 +16,7 @@ from emmodel.utils import YearTime
 class DataManager:
     i_folder: str
     o_folder: str
+    meta_filename: str = "meta.yaml"
     locations: List[str] = None
 
     def __post_init__(self):
@@ -39,7 +40,7 @@ class DataManager:
                     raise ValueError(f"{location} not in meta file.")
 
     def get_meta(self):
-        with open(self.i_folder / "meta.yaml", "r") as f:
+        with open(self.i_folder / self.meta_filename, "r") as f:
             meta = yaml.load(f, Loader=yaml.FullLoader)
         default = meta.pop("default")
         for location in meta:


### PR DESCRIPTION
**Description of changes:**
Allow the file name of meta file to differ from `meta.yaml`.

**Details:**
I want to be able to run multiple model variants using the same input directory. I can accomplish this by having `meta_1.yaml`, `meta_2.yaml`, etc, and also by varying the output directory (which is already possible). However the filepath for the meta file is currently fixed at `meta.yaml`, so this resolves that road block. 

I haven't tested that this works.