### PR TITLE
Feature/fix xticks

### DIFF
--- a/src/emmodel/data.py
+++ b/src/emmodel/data.py
@@ -84,7 +84,7 @@ class DataManager:
         time_end = self.meta[location][f"time_end_{time_end_id}"]
         time_unit = self.meta[location]["time_unit"]
         year_time = get_yeartime(df, col_year, col_time, time_unit)
-        time_ub = time_end - year_time.min()
+        time_ub = time_end - year_time.min() + 1
         return df[df["time"] <= time_ub].reset_index(drop=True)
 
     def truncate_time(self,

--- a/src/emmodel/model.py
+++ b/src/emmodel/model.py
@@ -214,6 +214,8 @@ def plot_data(df: pd.DataFrame,
 
     years = df[col_year].unique()
     year_heads = (years - df[col_year].min())*units_per_year + 1
+    offset = df.loc[df.year_id == df[col_year].min(), time_unit].min()
+    year_heads = year_heads - offset + 1
 
     axs = plt.subplots(2, figsize=(2.5*len(years), 10))[1]
     ax = axs[0]
@@ -228,7 +230,6 @@ def plot_data(df: pd.DataFrame,
         ax.axvline(time, linestyle="--", color="gray")
     ax.set_ylabel("deaths")
     ax.set_xlabel("time")
-
     return ax, axs
 
 
@@ -252,6 +253,8 @@ def plot_time_trend(ax: plt.Axes, df: pd.DataFrame,
     units_per_year = 52 if time_unit == "week" else 12
     years = df[col_year].unique()
     year_heads = (years - df[col_year].min())*units_per_year + 1
+    offset = df.loc[df.year_id == df[col_year].min(), time_unit].min()
+    year_heads = year_heads - offset + 1
     ax.set_xticks(year_heads)
     ax.set_xticklabels(years)
     ax.set_xlabel("time")


### PR DESCRIPTION
@zhengp0 The commit would return the correct `year_heads`, the plots would correctly reflect the years, but two plots don't have xaxis sharing the same scale. I have tried to fix that, but didn't work. Do you know why?